### PR TITLE
pandoc_download.py: add _get_pandoc_urls function

### DIFF
--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -38,7 +38,8 @@ def _get_pandoc_urls(version="latest"):
     :return: str version: actual pandoc version. (e.g. "lastest" will be resolved to the actual one)
     """
     # url to pandoc download page
-    url = "https://github.com/jgm/pandoc/releases/" + ("tag/" if version != "latest" else "") + version
+    url = "https://github.com/jgm/pandoc/releases/" + \
+        ("tag/" if version != "latest" else "") + version
     # read the HTML content
     response = urlopen(url)
     content = response.read()
@@ -57,7 +58,8 @@ def _get_pandoc_urls(version="latest"):
     # parse pandoc_urls from list to dict
     # py26 don't like dict comprehension. Use this one instead when py26 support is dropped
     # pandoc_urls = {ext2platform[url_frag[-3:]]: ("https://github.com" + url_frag) for url_frag in pandoc_urls_list}
-    pandoc_urls = dict((ext2platform[url_frag[-3:]], ("https://github.com" + url_frag)) for url_frag in pandoc_urls_list)
+    pandoc_urls = dict((ext2platform[
+                       url_frag[-3:]], ("https://github.com" + url_frag)) for url_frag in pandoc_urls_list)
     return pandoc_urls, version
 
 

--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -45,7 +45,7 @@ def _get_pandoc_urls(version="latest"):
     # regex for the binaries
     regex = re.compile(r"/jgm/pandoc/releases/download/.*\.(?:msi|deb|pkg)")
     # a list of urls to the bainaries
-    pandoc_urls_list = regex.findall(content.decode())
+    pandoc_urls_list = regex.findall(content.decode("utf-8"))
     # actual pandoc version
     version = pandoc_urls_list[0].split('/')[5]
     # dict that lookup the platform from binary extension
@@ -55,7 +55,9 @@ def _get_pandoc_urls(version="latest"):
         'pkg': 'darwin'
     }
     # parse pandoc_urls from list to dict
-    pandoc_urls = {ext2platform[url_frag[-3:]]: ("https://github.com" + url_frag) for url_frag in pandoc_urls_list}
+    # py26 don't like dict comprehension. Use this one instead when py26 support is dropped
+    # pandoc_urls = {ext2platform[url_frag[-3:]]: ("https://github.com" + url_frag) for url_frag in pandoc_urls_list}
+    pandoc_urls = dict((ext2platform[url_frag[-3:]], ("https://github.com" + url_frag)) for url_frag in pandoc_urls_list)
     return pandoc_urls, version
 
 

--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -17,18 +17,31 @@ except ImportError:
 # Uses sys.platform keys, but removes the 2 from linux2
 # Adding a new platform means implementing unpacking in "DownloadPandocCommand"
 # and adding the URL here
-# When updating pandoc version, update the following 2 variables
+
+
+def _get_pandoc_url(version=None):
+    """Get the urls of pandoc's binaries
+    :param str version: pandoc version. e.g. "1.19.1"
+    :return: str pandoc_urls: a dictionary with keys as system platform
+        and values as the url pointing to respective binaries
+    """
+    deb_subffix = "-1"
+
+    url_base = "https://github.com/jgm/pandoc/releases/download/" + \
+        version + "/pandoc-" + version
+
+    pandoc_urls = {
+        "win32": url_base + "-windows.msi",
+        "linux": url_base + deb_subffix + "-amd64.deb",
+        "darwin": url_base + "-osx.pkg"
+    }
+    return pandoc_urls
+
+
+# When updating pandoc version, update the following variable
 INCLUDED_PANDOC_VERSION = "1.19.1"
-DEB_SUBFFIX = "-1"
+PANDOC_URLS = _get_pandoc_url(INCLUDED_PANDOC_VERSION)
 
-URL_BASE = "https://github.com/jgm/pandoc/releases/download/" + \
-    INCLUDED_PANDOC_VERSION + "/pandoc-" + INCLUDED_PANDOC_VERSION
-
-PANDOC_URLS = {
-    "win32": URL_BASE + "-windows.msi",
-    "linux": URL_BASE + DEB_SUBFFIX + "-amd64.deb",
-    "darwin": URL_BASE + "-osx.pkg"
-}
 
 DEFAULT_TARGET_FOLDER = {
     "win32": "~\\AppData\\Local\\Pandoc",

--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -13,6 +13,8 @@ try:
 except ImportError:
     from urllib import urlopen
 
+# hard-code version for now
+INCLUDED_PANDOC_VERSION = "1.19.1"
 
 DEFAULT_TARGET_FOLDER = {
     "win32": "~\\AppData\\Local\\Pandoc",
@@ -146,8 +148,7 @@ def download_pandoc(url=None, targetfolder=None, version=None):
     """
     # get pandoc_urls
     if version is None:
-        # hard-code version for now
-        version = "1.19.1"
+        version = INCLUDED_PANDOC_VERSION
     pandoc_urls = _get_pandoc_urls(version)
 
     pf = sys.platform

--- a/pypandoc/pandoc_download.py
+++ b/pypandoc/pandoc_download.py
@@ -55,7 +55,7 @@ def _get_pandoc_urls(version="latest"):
         'pkg': 'darwin'
     }
     # parse pandoc_urls from list to dict
-    pandoc_urls = {ext2platform[url[-3:]]: url for url in pandoc_urls_list}
+    pandoc_urls = {ext2platform[url_frag[-3:]]: ("https://github.com" + url_frag) for url_frag in pandoc_urls_list}
     return pandoc_urls, version
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands =
 	python --version
 	python -c "import pypandoc; print(pypandoc.get_pandoc_version())"
 	# make sure we use our own pandoc version
- 	python -c "import sys; import pypandoc; from pypandoc.pandoc_download import INCLUDED_PANDOC_VERSION as IPV; pypandoc.get_pandoc_version() == IPV or sys.exit(-1)"
+ 	python -c "import sys; import pypandoc; _, version = pypandoc.pandoc_download._get_pandoc_urls(); pypandoc.get_pandoc_version() == version or sys.exit(-1)"
 	python tests.py
 
 [flake8]


### PR DESCRIPTION
so that we can

- specify pandoc version as “latest” and parse from HTML automatically
- and need not to specify the deb_suffix but parse from HTML automatically